### PR TITLE
Fix req to create run

### DIFF
--- a/marquez_client/client.py
+++ b/marquez_client/client.py
@@ -256,7 +256,7 @@ class MarquezClient(object):
             payload['nominalEndTime'] = nominal_end_time
 
         if run_args:
-            payload['runArgs'] = run_args
+            payload['args'] = run_args
 
         response = self._post(
             self._url('/namespaces/{0}/jobs/{1}/runs',

--- a/marquez_client/client_wo.py
+++ b/marquez_client/client_wo.py
@@ -159,7 +159,7 @@ class MarquezWriteOnlyClient(object):
             payload['nominalEndTime'] = nominal_end_time
 
         if run_args:
-            payload['runArgs'] = run_args
+            payload['args'] = run_args
 
         response = self._backend.post(
             self._path('/namespaces/{0}/jobs/{1}/runs',

--- a/tests/test_marquez_client.py
+++ b/tests/test_marquez_client.py
@@ -288,7 +288,7 @@ class TestMarquezClient(unittest.TestCase):
             'startedAt': f'{action_at}',
             'endedAt': None,
             'durationMs': None,
-            'run_args': {
+            'args': {
                 "email": "me@mycorp.com",
                 "emailOnFailure": "true",
                 "emailOnRetry": "true",
@@ -307,7 +307,7 @@ class TestMarquezClient(unittest.TestCase):
         )
 
         assert response['id'] is not None
-        assert str(response['run_args']) == str(run_args)
+        assert str(response['args']) == str(run_args)
         assert str(response['startedAt']) == action_at
 
     @mock.patch("marquez_client.client.MarquezClient._post")


### PR DESCRIPTION
This PR fixes how we pass args when creating a run (see [Run API](https://marquezproject.github.io/marquez/openapi.html#tag/Jobs/paths/~1namespaces~1{namespace}~1jobs~1{job}~1runs/post))